### PR TITLE
added support for using different images on different displays

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ Update image cache with multiple monitors, spanning
 Update image cache with solid background only (ignore errors)
 `multilockscreen -u . --fx color --color 5833ff`
 
+Update image cache with different background images
+`multilockscreen -u ~/Wallpapers/image1.png -u ~/Wallpapers/image2.png --fx dimpixel --display 1`
+
 Lock screen with blur effect
 `multilockscreen --lock blur`
 

--- a/multilockscreen
+++ b/multilockscreen
@@ -199,21 +199,34 @@ get_display_list () {
 	done
 }
 
-# get image path, sets $USER_WALL
-# if arg is file, return that
-# if arg is dir, return random image
+# get image path, sets $USER_WALL_LIST
+# if arg is files, return that
+# if arg is dir, return random images
 get_user_wall() {
 
-	local path="$1"
+	local paths=("$@")
 
-	if [ ! -d "$path" ]; then
-		USER_WALL="$path"
-		return
+	# check to see if first item is a directory
+	if [ -d "${paths[0]}" ]; then
+		dir=("${paths[0]}"/*)
+		unset paths
 	fi
-	dir=("$path"/*)
-	rdir="${dir[RANDOM % ${#dir[@]}]}"
-	get_user_wall "$rdir"
 
+	# select random wallpaper from directory
+	if [ "$span_image" = false ] && [ -v dir ]; then
+		for display in "${DISPLAY_LIST[@]}"; do
+			paths+=("${dir[RANDOM % ${#dir[@]}]}")
+		done
+	fi
+
+	if [ "$span_image" = true ] && [ -v dir ]; then
+		echo 'here'
+		paths+=("${dir[RANDOM % ${#dir[@]}]}")
+	fi
+
+	for path in "${paths[@]}"; do
+		USER_WALL_LIST+=("$path")
+	done
 }
 
 # scale base image and generate effects
@@ -386,17 +399,17 @@ purge_cache () {
 # update lockscreen and wallpaper images
 update () {
 
-	local image="$1"
+	local images=("$@")
 
 	echo "Updating Image Cache..."
 	mkdir -p "$CACHE_DIR" &>/dev/null
 
-	get_user_wall "$image" # USER_WALL
-	echo "Original Image: $USER_WALL"
-
 	get_display_list # DISPLAY_LIST
 	get_total_size # TOTAL_SIZE
 	echo "Detected ${#DISPLAY_LIST[@]} Displays @ $TOTAL_SIZE Resolution"
+
+	get_user_wall "${images[@]}" # USER_WALL_LIST
+	echo "Original Image(s): ${USER_WALL_LIST[@]##*/}"
 
 	# Prepare description box to obtain width for positioning
 	if [ -z "$description" ]; then
@@ -408,7 +421,9 @@ update () {
 		local descheight=$(identify -format "%[fx:h]" "$DESCRECT")
 	fi
 
-	for display in "${DISPLAY_LIST[@]}"; do
+	for ((i=0; i<${#DISPLAY_LIST[@]}; i++)); do
+		display="${DISPLAY_LIST[$i]}"
+		USER_WALL="${USER_WALL_LIST[$i]}"
 
 		IFS=' ' read -r -a dinfo  <<< "$display"
 		local id="${dinfo[0]}"
@@ -610,7 +625,7 @@ for arg in "$@"; do
 	case "$1" in
 		-u | --update)
 			runupdate=true
-			imagepath="$2"
+			imagepaths+=("$2")
 			shift 2
 			;;
 
@@ -692,7 +707,7 @@ for arg in "$@"; do
 done
 
 # Run image generation
-[[ $runupdate ]] && update "$imagepath"
+[[ $runupdate ]] && update "${imagepaths[@]}"
 
 # Activate lockscreen
 [[ $runlock ]] && lockselect "$lockstyle" && \

--- a/multilockscreen
+++ b/multilockscreen
@@ -165,7 +165,7 @@ logical_px() {
 	# get dpi value from xdpyinfo
 	local DPI
 	DPI=$(xdpyinfo | sed -En "s/\s*resolution:\s*([0-9]*)x([0-9]*)\s.*/\\$direction/p" | head -n1)
-	
+
 	# return the default value if no DPI is set
 	if [ -z "$DPI" ]; then
 		echo "$pixels"
@@ -199,40 +199,59 @@ get_display_list () {
 	done
 }
 
-# get image path, sets $USER_WALL_LIST
-# if arg is files, return that
-# if arg is dir, return random images
-get_user_wall() {
+# populate $WALL_LIST depending on number of displays and images passed
+get_wall_list() {
 
 	local paths=("$@")
+	declare -ga WALL_LIST
 
-	# check to see if first item is a directory
-	if [ -d "${paths[0]}" ]; then
-		dir=("${paths[0]}"/*)
-		unset paths
+	# multiple images and spanning conflict, bail out
+	if [ "${#paths[@]}" -gt 1 ] && [ "$span_image" = true ]; then
+		echo "ERROR: can't use --span with multiple images"
+		exit 1
 	fi
 
-	# select random wallpaper from directory
-	if [ "$span_image" = false ] && [ -v dir ]; then
-		for display in "${DISPLAY_LIST[@]}"; do
-			paths+=("${dir[RANDOM % ${#dir[@]}]}")
+	# if # paths is 1
+	if [ "${#paths[@]}" -eq 1 ]; then
+		for ((i=0; i<${#DISPLAY_LIST[@]}; i++)); do
+			# add same image to $WALL_LIST for each display
+			get_image "${paths[0]}"
 		done
-	fi
 
-	if [ "$span_image" = true ] && [ -v dir ]; then
-		paths+=("${dir[RANDOM % ${#dir[@]}]}")
-	fi
-
-	# set image each display
-	if [ "${#paths[@]}" -eq 1 ] && [ ! -v dir ]; then
-		for ((i=1; i<${#DISPLAY_LIST[@]}; i++)); do
-			paths+=("${paths[0]}")
+	# if # of paths equals # of displays
+	elif [ ${#paths[@]} -eq "${#DISPLAY_LIST[@]}" ]; then
+		for ((i=0; i<${#DISPLAY_LIST[@]}; i++)); do
+			# add each image to $WALL_LIST
+			get_image "${paths[$i]}"
 		done
+
+	# if # of paths differ from # of display, bail out
+	else
+		echo "ERROR: ${#paths[@]} images provided for ${#DISPLAY_LIST[@]} displays!"
+		exit 1
+	fi
+}
+
+# get image path, append to $WALL_LIST
+get_image() {
+
+	local path="$1"
+
+	# we have a file
+	if [ -f "$path" ]; then
+		WALL_LIST+=("$path")
+		return
+	# we have a directory
+	elif [ -d "$path" ]; then
+		dir=("$path"/*)
+		rdir="${dir[RANDOM % ${#dir[@]}]}"
+		get_image "$rdir" # <-- calls itself
+	# not file or directory, bail out
+	else
+		echo "ERROR: invalid path" "$path"
+		exit 1
 	fi
 
-	for path in "${paths[@]}"; do
-		USER_WALL_LIST+=("$path")
-	done
 }
 
 # scale base image and generate effects
@@ -399,7 +418,7 @@ purge_cache () {
 	if [[ -d "$1" ]]; then
 		rm -r "$1"
 	fi
-	mkdir -p "$1" 
+	mkdir -p "$1"
 }
 
 # update lockscreen and wallpaper images
@@ -414,8 +433,8 @@ update () {
 	get_total_size # TOTAL_SIZE
 	echo "Detected ${#DISPLAY_LIST[@]} Displays @ $TOTAL_SIZE Resolution"
 
-	get_user_wall "${images[@]}" # USER_WALL_LIST
-	echo "Original Image(s): ${USER_WALL_LIST[@]##*/}"
+	get_wall_list "${images[@]}" # WALL_LIST
+	echo "Original Image(s): ${WALL_LIST[@]##*/}"
 
 	# Prepare description box to obtain width for positioning
 	if [ -z "$description" ]; then
@@ -429,7 +448,7 @@ update () {
 
 	for ((i=0; i<${#DISPLAY_LIST[@]}; i++)); do
 		display="${DISPLAY_LIST[$i]}"
-		USER_WALL="${USER_WALL_LIST[$i]}"
+		USER_WALL="${WALL_LIST[$i]}"
 
 		IFS=' ' read -r -a dinfo  <<< "$display"
 		local id="${dinfo[0]}"
@@ -461,7 +480,7 @@ update () {
 
 		echo "Display: $device ($id)"
 		echo "Resolution: $resolution"
-		
+
 		local path="$CACHE_DIR/$id-$device"
 		purge_cache "$path"
 
@@ -482,9 +501,9 @@ update () {
 			PARAM_DIMPIXEL="$PARAM_DIMPIXEL $RES_DIMPIXEL -geometry $position -composite "
 			PARAM_COLOR="$PARAM_COLOR $RES_COLOR -geometry $position -composite "
 		fi
-		
+
 	done
-	
+
 	purge_cache "$CUR_DIR"
 
 	if [ "$span_image" = true ] || [ ${#DISPLAY_LIST[@]} -lt 2 ]; then

--- a/multilockscreen
+++ b/multilockscreen
@@ -220,8 +220,14 @@ get_user_wall() {
 	fi
 
 	if [ "$span_image" = true ] && [ -v dir ]; then
-		echo 'here'
 		paths+=("${dir[RANDOM % ${#dir[@]}]}")
+	fi
+
+	# set image each display
+	if [ "${#paths[@]}" -eq 1 ] && [ ! -v dir ]; then
+		for ((i=1; i<${#DISPLAY_LIST[@]}; i++)); do
+			paths+=("${paths[0]}")
+		done
 	fi
 
 	for path in "${paths[@]}"; do


### PR DESCRIPTION
Added support for using multiple images for displays with support for random selection and spanning.

For example, if the user has 2 displays, this will render image1.png with the dimpixel effect and scale to display 1 including the loginbox. It will then use image2.png with the dimpixel effect and scale to display 2.
```
$ multilockscreen \
    -u ~/Wallpapers/image1.png \
    -u ~/Wallpapers/image2.png \
    --fx dimpixel --display 1
```
