### PR TITLE
Use `dunstctl` to (un)pause the dunst pre/post-lock.

### DIFF
--- a/multilockscreen
+++ b/multilockscreen
@@ -77,8 +77,9 @@ prelock() {
 		xset dpms "$lock_timeout"
 	fi
 	# pause dunst
-	if [ -n "$(pidof dunst)" ]; then
-		pkill -u "$USER" -USR1 dunst
+	if command -v dunstctl &>/dev/null
+	then
+		dunstctl set-paused true
 	fi
 }
 
@@ -137,8 +138,9 @@ postlock() {
 		xset dpms "$DEFAULT_TIMEOUT"
 	fi
 	# unpause dunst
-	if [ -n "$(pidof dunst)" ] ; then
-		pkill -u "$USER" -USR2 dunst
+	if command -v dunstctl &>/dev/null
+	then
+		dunstctl set-paused false
 	fi
 }
 


### PR DESCRIPTION
Please be aware that, the use of dunstctl means that users will be forced to have dunst v1.5.0 or newer installed.