### PR TITLE
Disable DPMS after unlocking if it was originally disabled

### DIFF
--- a/multilockscreen
+++ b/multilockscreen
@@ -67,6 +67,8 @@ init_config () {
 
 	# Original DPMS timeout
 	DEFAULT_TIMEOUT=$(cut -d ' ' -f4 <<< "$(xset q | sed -n '25p')")
+	# Original DPMS status
+	DEFAULT_DPMS=$(xset q | awk '/^[[:blank:]]*DPMS is/ {print $(NF)}')
 }
 
 # called before screen is locked
@@ -136,6 +138,9 @@ postlock() {
 	# restore default dpms timeout
 	if [ -n "$lock_timeout" ]; then
 		xset dpms "$DEFAULT_TIMEOUT"
+		if [ "$DEFAULT_DPMS" = "Disabled" ]; then
+			xset -dpms
+		fi
 	fi
 	# unpause dunst
 	if command -v dunstctl &>/dev/null


### PR DESCRIPTION
If `lock_timeout` is set, DPMS is enabled when the screen is locked. At the moment, when the screen is unlocked again, the default DPMS timeout is reset, but DPMS isn't disabled again if it was originally turned off, so the screen starts blanking. I added a variable `DEFAULT_DPMS` which reads the current DPMS status returned by `xset q`, and restores this setting when the screen unlocks again.

The fix is shamelessly copied from the upstream repo (https://github.com/pavanjadhaw/betterlockscreen/pull/151). :)