### PR TITLE
On demand cache

### DIFF
--- a/getlockimg
+++ b/getlockimg
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+
+set -eu
+
+IMAGE_PATHS=()
+DISPLAY_SIZES=()
+DISPLAY_OFFSETS=()
+EFFECT=none
+
+get_filename() {
+  local input_image="$1"
+  local effect="$2"
+  local size="$3"
+  local digest=$(echo "$input_image $effect $size" | md5sum)
+
+  echo "$CACHE_DIR/${digest:0:32}.png"
+}
+
+base_resize() {
+  local size="$3"
+  eval convert "$1" -resize "$size""^" -gravity center -extent "$size" "$2"
+}
+
+apply_dim_effect() {
+	local input="$1"
+	local output="$2"
+
+	eval convert "$input" \
+		-fill black -colorize "$DIM_LEVEL"% \
+		"$output"
+}
+
+apply_blur_effect() {
+  local input="$1"
+  local output="$2"
+  local size="$3"
+
+  blur_shrink=$(echo "scale=2; 20 / $BLUR_LEVEL" | bc)
+  blur_sigma=$(echo "scale=2; 0.6 * $BLUR_LEVEL" | bc)
+  eval convert "$input" \
+    -filter Gaussian \
+    -resize "$blur_shrink%" \
+    -define "filter:sigma=$blur_sigma" \
+    -resize "$size^" -gravity center -extent "$size" \
+    "$output"
+}
+
+apply_dimblur_effect() {
+  local input="$1"
+  local output="$2"
+  local size="$3"
+
+  blur_shrink=$(echo "scale=2; 20 / $BLUR_LEVEL" | bc)
+  blur_sigma=$(echo "scale=2; 0.6 * $BLUR_LEVEL" | bc)
+  eval convert "$input" \
+    -fill black -colorize "$DIM_LEVEL"% \
+    -filter Gaussian \
+    -resize "$blur_shrink%" \
+    -define "filter:sigma=$blur_sigma" \
+    -resize "$size^" -gravity center -extent "$size" \
+    "$output"
+}
+
+apply_pixel_effect() {
+  local input="$1"
+  local output="$2"
+
+  IFS=',' read -ra range <<< "$PIXEL_SCALE"
+  eval convert "$input" \
+    -scale "${range[0]}"% -scale "${range[1]}"% \
+    "$output"
+}
+
+apply_dimpixel_effect() {
+  local input="$1"
+  local output="$2"
+
+  IFS=',' read -ra range <<< "$PIXEL_SCALE"
+  eval convert "$input" \
+    -fill black -colorize "$DIM_LEVEL"% \
+    -scale "${range[0]}"% -scale "${range[1]}"% \
+    "$output"
+}
+
+apply_color_effect() {
+  local output="$1"
+  local size="$2"
+
+  eval convert -size "$size" canvas:\#"$SOLID_COLOR" "$output"
+}
+
+gen_image() {
+  mkdir -p "$CACHE_DIR"
+
+  local input="${IMAGE_PATHS[0]}"
+  local target_size="${DISPLAY_SIZES[0]}"
+
+  local resize_res=$(get_filename "$input" none "$target_size")
+  if [ ! -f "$resize_res" ]; then
+    base_resize "$input" "$resize_res" "$target_size"
+  fi
+
+  if [ "$EFFECT" = 'none' ]; then
+    echo $resize_res
+    exit 0
+  fi
+
+  local effect_res=$(get_filename "$input" $EFFECT "$target_size")
+  if [ ! -f "$effect_res" ]; then
+    case "$EFFECT" in
+      dim) apply_dim_effect "$resize_res" "$effect_res";;
+      blur) apply_blur_effect "$resize_res" "$effect_res" "$target_size";;
+      dimblur) apply_dimblur_effect "$resize_res" "$effect_res" "$target_size";;
+      pixel) apply_pixel_effect "$resize_res" "$effect_res";;
+      dimpixel) apply_dimpixel_effect "$resize_res" "$effect_res";;
+      color) apply_color_effect "$effect_res" "$target_size";;
+
+      *)
+        # TODO: Print a message about unrecognized effect?
+        exit 1
+        ;;
+    esac
+  fi
+
+  echo $effect_res
+}
+
+verify_args() {
+  if [ "${#IMAGE_PATHS[@]}" -ne 1 ]; then
+    # TODO: Add error msg
+    exit 1
+  fi
+
+  if [[ -d "${IMAGE_PATHS[0]}" ]]; then
+    # TODO: Add error msg
+    exit 1
+  fi
+
+  if [ "${#DISPLAY_SIZES[@]}" -ne 1 ]; then
+    # TODO: Add error msg
+    exit 1
+  fi
+
+  # TODO: verify cache dir is specified
+}
+
+for arg in "$@"; do
+  [[ "${arg:0:1}" = '-' ]] || continue
+
+  case "$1" in
+    --cachedir)
+      CACHE_DIR="$2"
+      shift 2
+      ;;
+
+    --img)
+      IMAGE_PATHS+=("$2")
+      shift 2
+      ;;
+
+    --display)
+      DISPLAY_SIZES+=("$2")
+      DISPLAY_OFFSETS+=("$3")
+      shift 3
+      ;;
+
+    --effect)
+      EFFECT="$2"
+      shift 2
+      ;;
+
+    --dim)
+      DIM_LEVEL="$2"
+      shift 2
+      ;;
+
+    --blur)
+      BLUR_LEVEL="$2"
+      shift 2
+      ;;
+
+    --pixel)
+      PIXEL_SCALE="$2"
+      shift 2
+      ;;
+
+    --color)
+      SOLID_COLOR="${2//\#/}"
+      shift 2
+      ;;
+
+    -h | --help | *)
+      # TODO: Add usage info
+      break
+      ;;
+  esac
+done
+
+verify_args
+gen_image

--- a/getlockimg
+++ b/getlockimg
@@ -14,11 +14,7 @@ get_composed_filename() {
 }
 
 get_single_filename() {
-	local input_image="$1"
-	local effect="$2"
-	local size="$3"
-	local digest=$(echo $input_image $effect $size | md5sum)
-
+	local digest=$(echo $@ | md5sum)
 	echo "$CACHE_DIR/${digest:0:32}.png"
 }
 
@@ -109,15 +105,33 @@ gen_single_image() {
 		exit 0
 	fi
 
-	local effect_res=$(get_single_filename "$input" $EFFECT "$target_size")
+	local effect_res=''
 	if [ ! -f "$effect_res" ]; then
 		case "$EFFECT" in
-			dim) apply_dim_effect "$resize_res" "$effect_res";;
-			blur) apply_blur_effect "$resize_res" "$effect_res" "$target_size";;
-			dimblur) apply_dimblur_effect "$resize_res" "$effect_res" "$target_size";;
-			pixel) apply_pixel_effect "$resize_res" "$effect_res";;
-			dimpixel) apply_dimpixel_effect "$resize_res" "$effect_res";;
-			color) apply_color_effect "$effect_res" "$target_size";;
+			dim)
+				effect_res=$(get_single_filename "$input" $EFFECT "$target_size" $DIM_LEVEL)
+				apply_dim_effect "$resize_res" "$effect_res"
+				;;
+			blur)
+				effect_res=$(get_single_filename "$input" $EFFECT "$target_size" $BLUR_LEVEL)
+				apply_blur_effect "$resize_res" "$effect_res" "$target_size"
+				;;
+			dimblur)
+				effect_res=$(get_single_filename "$input" $EFFECT "$target_size" $DIM_LEVEL $BLUR_LEVEL)
+				apply_dimblur_effect "$resize_res" "$effect_res" "$target_size"
+				;;
+			pixel)
+				effect_res=$(get_single_filename "$input" $EFFECT "$target_size" $PIXEL_SCALE)
+				apply_pixel_effect "$resize_res" "$effect_res"
+				;;
+			dimpixel)
+				effect_res=$(get_single_filename "$input" $EFFECT "$target_size" $DIM_LEVEL $PIXEL_SCALE)
+				apply_dimpixel_effect "$resize_res" "$effect_res"
+				;;
+			color)
+				effect_res=$(get_single_filename $EFFECT "$target_size" $SOLID_COLOR)
+				apply_color_effect "$effect_res" "$target_size"
+				;;
 
 			*)
 				# TODO: Print a message about unrecognized effect?

--- a/getlockimg
+++ b/getlockimg
@@ -226,7 +226,7 @@ for arg in "$@"; do
 
 		-h | --help | *)
 			# TODO: Add usage info
-			break
+			exit 0
 			;;
 	esac
 done

--- a/getlockimg
+++ b/getlockimg
@@ -2,23 +2,29 @@
 
 set -eu
 
+PROCESSED_SINGLES=()
 IMAGE_PATHS=()
 DISPLAY_SIZES=()
 DISPLAY_OFFSETS=()
 EFFECT=none
 
-get_filename() {
-  local input_image="$1"
-  local effect="$2"
-  local size="$3"
-  local digest=$(echo "$input_image $effect $size" | md5sum)
+get_composed_filename() {
+	local digest=$(echo $EFFECT ${PROCESSED_SINGLES[@]} ${DISPLAY_OFFSETS[@]} | md5sum)
+	echo "$CACHE_DIR/${digest:0:32}.png"
+}
 
-  echo "$CACHE_DIR/${digest:0:32}.png"
+get_single_filename() {
+	local input_image="$1"
+	local effect="$2"
+	local size="$3"
+	local digest=$(echo $input_image $effect $size | md5sum)
+
+	echo "$CACHE_DIR/${digest:0:32}.png"
 }
 
 base_resize() {
-  local size="$3"
-  eval convert "$1" -resize "$size""^" -gravity center -extent "$size" "$2"
+	local size="$3"
+	eval convert "$1" -resize "$size""^" -gravity center -extent "$size" "$2"
 }
 
 apply_dim_effect() {
@@ -31,170 +37,199 @@ apply_dim_effect() {
 }
 
 apply_blur_effect() {
-  local input="$1"
-  local output="$2"
-  local size="$3"
+	local input="$1"
+	local output="$2"
+	local size="$3"
 
-  blur_shrink=$(echo "scale=2; 20 / $BLUR_LEVEL" | bc)
-  blur_sigma=$(echo "scale=2; 0.6 * $BLUR_LEVEL" | bc)
-  eval convert "$input" \
-    -filter Gaussian \
-    -resize "$blur_shrink%" \
-    -define "filter:sigma=$blur_sigma" \
-    -resize "$size^" -gravity center -extent "$size" \
-    "$output"
+	blur_shrink=$(echo "scale=2; 20 / $BLUR_LEVEL" | bc)
+	blur_sigma=$(echo "scale=2; 0.6 * $BLUR_LEVEL" | bc)
+	eval convert "$input" \
+		-filter Gaussian \
+		-resize "$blur_shrink%" \
+		-define "filter:sigma=$blur_sigma" \
+		-resize "$size^" -gravity center -extent "$size" \
+		"$output"
 }
 
 apply_dimblur_effect() {
-  local input="$1"
-  local output="$2"
-  local size="$3"
+	local input="$1"
+	local output="$2"
+	local size="$3"
 
-  blur_shrink=$(echo "scale=2; 20 / $BLUR_LEVEL" | bc)
-  blur_sigma=$(echo "scale=2; 0.6 * $BLUR_LEVEL" | bc)
-  eval convert "$input" \
-    -fill black -colorize "$DIM_LEVEL"% \
-    -filter Gaussian \
-    -resize "$blur_shrink%" \
-    -define "filter:sigma=$blur_sigma" \
-    -resize "$size^" -gravity center -extent "$size" \
-    "$output"
+	blur_shrink=$(echo "scale=2; 20 / $BLUR_LEVEL" | bc)
+	blur_sigma=$(echo "scale=2; 0.6 * $BLUR_LEVEL" | bc)
+	eval convert "$input" \
+		-fill black -colorize "$DIM_LEVEL"% \
+		-filter Gaussian \
+		-resize "$blur_shrink%" \
+		-define "filter:sigma=$blur_sigma" \
+		-resize "$size^" -gravity center -extent "$size" \
+		"$output"
 }
 
 apply_pixel_effect() {
-  local input="$1"
-  local output="$2"
+	local input="$1"
+	local output="$2"
 
-  IFS=',' read -ra range <<< "$PIXEL_SCALE"
-  eval convert "$input" \
-    -scale "${range[0]}"% -scale "${range[1]}"% \
-    "$output"
+	IFS=',' read -ra range <<< "$PIXEL_SCALE"
+	eval convert "$input" \
+		-scale "${range[0]}"% -scale "${range[1]}"% \
+		"$output"
 }
 
 apply_dimpixel_effect() {
-  local input="$1"
-  local output="$2"
+	local input="$1"
+	local output="$2"
 
-  IFS=',' read -ra range <<< "$PIXEL_SCALE"
-  eval convert "$input" \
-    -fill black -colorize "$DIM_LEVEL"% \
-    -scale "${range[0]}"% -scale "${range[1]}"% \
-    "$output"
+	IFS=',' read -ra range <<< "$PIXEL_SCALE"
+	eval convert "$input" \
+		-fill black -colorize "$DIM_LEVEL"% \
+		-scale "${range[0]}"% -scale "${range[1]}"% \
+		"$output"
 }
 
 apply_color_effect() {
-  local output="$1"
-  local size="$2"
+	local output="$1"
+	local size="$2"
 
-  eval convert -size "$size" canvas:\#"$SOLID_COLOR" "$output"
+	eval convert -size "$size" canvas:\#"$SOLID_COLOR" "$output"
 }
 
-gen_image() {
-  mkdir -p "$CACHE_DIR"
+gen_single_image() {
+	local input="$1"
+	local target_size="$2"
 
-  local input="${IMAGE_PATHS[0]}"
-  local target_size="${DISPLAY_SIZES[0]}"
+	local resize_res=$(get_single_filename "$input" none "$target_size")
+	if [ ! -f "$resize_res" ]; then
+		base_resize "$input" "$resize_res" "$target_size"
+	fi
 
-  local resize_res=$(get_filename "$input" none "$target_size")
-  if [ ! -f "$resize_res" ]; then
-    base_resize "$input" "$resize_res" "$target_size"
-  fi
+	if [ "$EFFECT" = 'none' ]; then
+		echo $resize_res
+		exit 0
+	fi
 
-  if [ "$EFFECT" = 'none' ]; then
-    echo $resize_res
-    exit 0
-  fi
+	local effect_res=$(get_single_filename "$input" $EFFECT "$target_size")
+	if [ ! -f "$effect_res" ]; then
+		case "$EFFECT" in
+			dim) apply_dim_effect "$resize_res" "$effect_res";;
+			blur) apply_blur_effect "$resize_res" "$effect_res" "$target_size";;
+			dimblur) apply_dimblur_effect "$resize_res" "$effect_res" "$target_size";;
+			pixel) apply_pixel_effect "$resize_res" "$effect_res";;
+			dimpixel) apply_dimpixel_effect "$resize_res" "$effect_res";;
+			color) apply_color_effect "$effect_res" "$target_size";;
 
-  local effect_res=$(get_filename "$input" $EFFECT "$target_size")
-  if [ ! -f "$effect_res" ]; then
-    case "$EFFECT" in
-      dim) apply_dim_effect "$resize_res" "$effect_res";;
-      blur) apply_blur_effect "$resize_res" "$effect_res" "$target_size";;
-      dimblur) apply_dimblur_effect "$resize_res" "$effect_res" "$target_size";;
-      pixel) apply_pixel_effect "$resize_res" "$effect_res";;
-      dimpixel) apply_dimpixel_effect "$resize_res" "$effect_res";;
-      color) apply_color_effect "$effect_res" "$target_size";;
+			*)
+				# TODO: Print a message about unrecognized effect?
+				exit 1
+				;;
+		esac
+	fi
 
-      *)
-        # TODO: Print a message about unrecognized effect?
-        exit 1
-        ;;
-    esac
-  fi
+	echo $effect_res
+}
 
-  echo $effect_res
+compose_singles() {
+	local composed=$(get_composed_filename)
+
+	convert -size $TOTAL_SIZE 'xc:blue' "$composed"
+
+	local compose_param=()
+	for ((i = 0; i < ${#IMAGE_PATHS[@]}; ++i)); do
+		local image="${IMAGE_PATHS[$i]}"
+		local geometry="${DISPLAY_OFFSETS[$i]}"
+		compose_param+=("$compose_param" "$image" -geometry "$geometry" -composite)
+	done
+	convert "$composed" "${compose_param[@]}" "$composed"
+	echo $composed
+}
+
+gen_lock_image() {
+	for ((i = 0; i < ${#IMAGE_PATHS[@]}; ++i)); do
+		local image="${IMAGE_PATHS[$i]}"
+		local target_size="${DISPLAY_SIZES[$i]}"
+		PROCESSED_SINGLES+=("$(gen_single_image "$image" "$target_size")")
+	done
+
+	if [ "${#IMAGE_PATHS[@]}" -eq 1 ]; then
+		echo ${PROCESSED_SINGLES[0]}
+	else
+		compose_singles
+	fi
 }
 
 verify_args() {
-  if [ "${#IMAGE_PATHS[@]}" -ne 1 ]; then
-    # TODO: Add error msg
-    exit 1
-  fi
+	# TODO: verify cache dir is specified
+	mkdir -p "$CACHE_DIR"
 
-  if [[ -d "${IMAGE_PATHS[0]}" ]]; then
-    # TODO: Add error msg
-    exit 1
-  fi
+	if [ "${#IMAGE_PATHS[@]}" -ne "${#DISPLAY_SIZES[@]}" ]; then
+		# For now, only support the case where the number of images and displays are
+		# equal, which is what the multilockscreen calling script enforces.
+		# TODO: Add error msg
+		# TODO: We could be more clever here? If we have more images than displays,
+		# use a random subset?
+		exit 1
+	fi
 
-  if [ "${#DISPLAY_SIZES[@]}" -ne 1 ]; then
-    # TODO: Add error msg
-    exit 1
-  fi
-
-  # TODO: verify cache dir is specified
+	# TODO: Verify passed in images all exist
 }
 
 for arg in "$@"; do
-  [[ "${arg:0:1}" = '-' ]] || continue
+	[[ "${arg:0:1}" = '-' ]] || continue
 
-  case "$1" in
-    --cachedir)
-      CACHE_DIR="$2"
-      shift 2
-      ;;
+	case "$1" in
+		--cachedir)
+			CACHE_DIR="$2"
+			shift 2
+			;;
 
-    --img)
-      IMAGE_PATHS+=("$2")
-      shift 2
-      ;;
+		--img)
+			IMAGE_PATHS+=("$2")
+			shift 2
+			;;
 
-    --display)
-      DISPLAY_SIZES+=("$2")
-      DISPLAY_OFFSETS+=("$3")
-      shift 3
-      ;;
+		--display)
+			DISPLAY_SIZES+=("$2")
+			DISPLAY_OFFSETS+=("$3")
+			shift 3
+			;;
 
-    --effect)
-      EFFECT="$2"
-      shift 2
-      ;;
+		--effect)
+			EFFECT="$2"
+			shift 2
+			;;
 
-    --dim)
-      DIM_LEVEL="$2"
-      shift 2
-      ;;
+		--totalsize)
+			TOTAL_SIZE="$2"
+			shift 2
+			;;
 
-    --blur)
-      BLUR_LEVEL="$2"
-      shift 2
-      ;;
+		--dim)
+			DIM_LEVEL="$2"
+			shift 2
+			;;
 
-    --pixel)
-      PIXEL_SCALE="$2"
-      shift 2
-      ;;
+		--blur)
+			BLUR_LEVEL="$2"
+			shift 2
+			;;
 
-    --color)
-      SOLID_COLOR="${2//\#/}"
-      shift 2
-      ;;
+		--pixel)
+			PIXEL_SCALE="$2"
+			shift 2
+			;;
 
-    -h | --help | *)
-      # TODO: Add usage info
-      break
-      ;;
-  esac
+		--color)
+			SOLID_COLOR="${2//\#/}"
+			shift 2
+			;;
+
+		-h | --help | *)
+			# TODO: Add usage info
+			break
+			;;
+	esac
 done
 
 verify_args
-gen_image
+gen_lock_image

--- a/multilockscreen
+++ b/multilockscreen
@@ -95,7 +95,6 @@ lock() {
 	local image="$1"
 
 	i3lock \
-		--no-verify \
 		-i "$image" \
 		-c "$bgcolor" \
 		--screen "$display_on" \
@@ -350,7 +349,7 @@ update () {
 			USER_WALL="${USER_WALL// /\\ }"
 		fi
 
-		IFS=' ' read -r -a dinfo	<<< "$display"
+		IFS=' ' read -r -a dinfo  <<< "$display"
 		local id="${dinfo[0]}"
 		local geometry="${dinfo[2]}"
 
@@ -485,52 +484,52 @@ usage() {
 	echo
 	echo "Usage: multilockscreen [-u <PATH>] [-l <EFFECT>] [-w <EFFECT>]"
 	echo
-	echo "	-u --update <PATH>"
-	echo "			Update lock screen image"
+	echo "  -u --update <PATH>"
+	echo "      Update lock screen image"
 	echo
-	echo "	-l --lock <EFFECT>"
-	echo "			Lock screen with cached image"
+	echo "  -l --lock <EFFECT>"
+	echo "      Lock screen with cached image"
 	echo
-	echo "	-w --wall <EFFECT>"
-	echo "			Set wallpaper with cached image"
+	echo "  -w --wall <EFFECT>"
+	echo "      Set wallpaper with cached image"
 	echo
 	echo "Additional arguments:"
 	echo
-	echo "	--display <N>"
-	echo "			Set display to draw loginbox"
+	echo "  --display <N>"
+	echo "      Set display to draw loginbox"
 	echo
-	echo "	--span"
-	echo "			Scale image to span multiple displays"
+	echo "  --span"
+	echo "      Scale image to span multiple displays"
 	echo
-	echo "	--off <N>"
-	echo "			Turn display off after N minutes"
+	echo "  --off <N>"
+	echo "      Turn display off after N minutes"
 	echo
-	echo "	--fx <EFFECT,EFFECT,EFFECT>"
-	echo "			List of effects to generate"
+	echo "  --fx <EFFECT,EFFECT,EFFECT>"
+	echo "      List of effects to generate"
 	echo
-	echo "	--desc <DESCRIPTION>"
-	echo "			Set a description for the new lock screen image"
-	echo "			(Only has an effect in combination with --update)"
+	echo "  --desc <DESCRIPTION>"
+	echo "      Set a description for the new lock screen image"
+	echo "      (Only has an effect in combination with --update)"
 	echo
-	echo "	--show-layout"
-	echo "			Show current keyboard layout"
+	echo "  --show-layout"
+	echo "      Show current keyboard layout"
 	echo
-	echo "	-- <ARGS>"
-	echo "			Pass additional arguments to i3lock"
+	echo "  -- <ARGS>"
+	echo "      Pass additional arguments to i3lock"
 	echo
 	echo "Effects arguments:"
 	echo
-	echo "	--dim <N>"
-	echo "			Dim image N percent (0-100)"
+	echo "  --dim <N>"
+	echo "      Dim image N percent (0-100)"
 	echo
-	echo "	--blur <N>"
-	echo "			Blur image N amount (0.0-1.0)"
+	echo "  --blur <N>"
+	echo "      Blur image N amount (0.0-1.0)"
 	echo
-	echo "	--pixel <N,N>"
-	echo "			Pixelate image with N shrink and N grow (unsupported)"
+	echo "  --pixel <N,N>"
+	echo "      Pixelate image with N shrink and N grow (unsupported)"
 	echo
-	echo "	--color <HEX>"
-	echo "			Solid color background with HEX"
+	echo "  --color <HEX>"
+	echo "      Solid color background with HEX"
 	echo
 	exit 1
 }

--- a/multilockscreen
+++ b/multilockscreen
@@ -95,7 +95,7 @@ lock() {
 	local image="$1"
 
 	i3lock \
-    --no-verify \
+		--no-verify \
 		-i "$image" \
 		-c "$bgcolor" \
 		--screen "$display_on" \
@@ -277,41 +277,6 @@ get_image() {
 
 }
 
-# scale base image and generate effects
-resize_and_render () {
-	local base="$1"
-	local resolution="$2"
-
-  local common_image_params=(--cachedir "$CACHE_DIR" --img "$base" --display "$resolution" "0x0")
-
-	# resource paths
-  RES_RESIZE="$(getlockimg "${common_image_params[@]}")"
-
-  # The following variables are intentionally assigned to a (probably)
-  # non-existent file. The rest of this script uses the existence of these files
-  # as a proxy for "is this effect enabled in the fx_list". If an effect is
-  # desired, the corresponding RES_* variable will be assigned to the result
-  # of `getlockimg` in the case-statement below.
-	RES_DIM="$CACHE_DIR/effect-is-disabled.png"
-	RES_BLUR="$CACHE_DIR/effect-is-disabled.png"
-	RES_DIMBLUR="$CACHE_DIR/effect-is-disabled.png"
-	RES_PIXEL="$CACHE_DIR/effect-is-disabled.png"
-	RES_DIMPIXEL="$CACHE_DIR/effect-is-disabled.png"
-	RES_COLOR="$CACHE_DIR/effect-is-disabled.png"
-
-	# effects
-	for effect in "${fx_list[@]}"; do
-		case $effect in
-      dim) RES_DIM="$(getlockimg "${common_image_params[@]}" --effect dim --dim "$dim_level")";;
-      blur) RES_BLUR="$(getlockimg "${common_image_params[@]}" --effect blur --blur "$blur_level")";;
-      dimblur) RES_DIMBLUR="$(getlockimg "${common_image_params[@]}" --effect dimblur --dim "$dim_level" --blur "$blur_level")";;
-      pixel) RES_PIXEL="$(getlockimg "${common_image_params[@]}" --effect pixel --pixel "$pixel_scale")";;
-      dimpixel) RES_DIMPIXEL="$(getlockimg "${common_image_params[@]}" --effect dimpixel --dim "$dim_level" --pixel "$pixel_scale")";;
-      color) RES_COLOR="$(getlockimg "${common_image_params[@]}" --effect color --color "$solid_color")";;
-		esac
-	done
-}
-
 # create loginbox rectangle, set $RECTANGLE
 create_loginbox () {
 	RECTANGLE="$CUR_DIR/rectangle.png"
@@ -353,7 +318,6 @@ purge_cache () {
 
 # update lockscreen and wallpaper images
 update () {
-
 	local images=("$@")
 
 	echof act "Updating image cache..."
@@ -376,6 +340,7 @@ update () {
 		local descheight=$(identify -format "%[fx:h]" "$DESCRECT")
 	fi
 
+	local display_params=()
 	for ((i=0; i<${#DISPLAY_LIST[@]}; i++)); do
 		display="${DISPLAY_LIST[$i]}"
 		USER_WALL="${WALL_LIST[$i]}"
@@ -385,14 +350,15 @@ update () {
 			USER_WALL="${USER_WALL// /\\ }"
 		fi
 
-		IFS=' ' read -r -a dinfo  <<< "$display"
+		IFS=' ' read -r -a dinfo	<<< "$display"
 		local id="${dinfo[0]}"
-		local device="${dinfo[1]}"
 		local geometry="${dinfo[2]}"
 
 		read -r -a cols <<< "${geometry//[x+-]/ }"
 		local position="${geometry#*${cols[1]}}"
 		local resolution="${geometry%${position}*}"
+
+		display_params+=("--img" "$USER_WALL" "--display" "$resolution" "$position")
 
 		if [[ $id -eq "$display_on" ]] || [[ "$display_on" -eq 0 ]]; then
 
@@ -412,66 +378,37 @@ update () {
 			descrect_y=$((pos_y + res_y - descheight - $(logical_px 20 2)))
 			positions_desc+=("+$((descrect_x))+$((descrect_y))")
 		fi
+	done
 
-		if [ "$span_image" = true ]; then
-			if [ "$id" -gt 1 ]; then
-				continue
-			else
-				device="[span]"
-				id="*"
-				resolution="$TOTAL_SIZE"
-			fi
-		fi
+	local compose_params=(--cachedir "$CACHE_DIR" --totalsize "$TOTAL_SIZE")
+	if [ "$span_image" = true ]; then
+		compose_params+=(--img "${IMAGE_PATHS[0]}" --display "$TOTAL_SIZE" "+0+0")
+	else
+		compose_params+=(${display_params[@]})
+	fi
 
-		echof info "Processing display: $device ($id)"
-		echof info "Resolution: $resolution"
-
-		if [ "$span_image" = true ]; then
-			resize_and_render "$USER_WALL" "$resolution"
-		else
-			resize_and_render "$USER_WALL" "$resolution"
-
-			PARAM_RESIZE="$PARAM_RESIZE $RES_RESIZE -geometry $position -composite "
-			PARAM_DIM="$PARAM_DIM $RES_DIM -geometry $position -composite "
-			PARAM_BLUR="$PARAM_BLUR $RES_BLUR -geometry $position -composite "
-			PARAM_DIMBLUR="$PARAM_DIMBLUR $RES_DIMBLUR -geometry $position -composite "
-			PARAM_PIXEL="$PARAM_PIXEL $RES_PIXEL -geometry $position -composite "
-			PARAM_DIMPIXEL="$PARAM_DIMPIXEL $RES_DIMPIXEL -geometry $position -composite "
-			PARAM_COLOR="$PARAM_COLOR $RES_COLOR -geometry $position -composite "
-		fi
-
+	RES_RESIZE="$(getlockimg "${compose_params[@]}")"
+	for effect in "${fx_list[@]}"; do
+		case $effect in
+			dim) RES_DIM="$(getlockimg "${compose_params[@]}" --effect dim --dim "$dim_level")";;
+			blur) RES_BLUR="$(getlockimg "${compose_params[@]}" --effect blur --blur "$blur_level")";;
+			dimblur) RES_DIMBLUR="$(getlockimg "${compose_params[@]}" --effect dimblur --dim "$dim_level" --blur "$blur_level")";;
+			pixel) RES_PIXEL="$(getlockimg "${compose_params[@]}" --effect pixel --pixel "$pixel_scale")";;
+			dimpixel) RES_DIMPIXEL="$(getlockimg "${compose_params[@]}" --effect dimpixel --dim "$dim_level" --pixel "$pixel_scale")";;
+			color) RES_COLOR="$(getlockimg "${compose_params[@]}" --effect color --color "$solid_color")";;
+		esac
 	done
 
 	purge_cache "$CUR_DIR"
 
-	if [ "$span_image" = true ] || [ ${#DISPLAY_LIST[@]} -lt 2 ]; then
-		echof act "Rendering final wallpaper images..."
-		[[ -f "$RES_RESIZE" ]] && cp $RES_RESIZE $CUR_W_RESIZE
-		[[ -f "$RES_DIM" ]] && cp $RES_DIM $CUR_W_DIM
-		[[ -f "$RES_BLUR" ]] && cp $RES_BLUR $CUR_W_BLUR
-		[[ -f "$RES_DIMBLUR" ]] && cp $RES_DIMBLUR $CUR_W_DIMBLUR
-		[[ -f "$RES_PIXEL" ]] && cp $RES_PIXEL $CUR_W_PIXEL
-		[[ -f "$RES_DIMPIXEL" ]] && cp $RES_DIMPIXEL $CUR_W_DIMPIXEL
-		[[ -f "$RES_COLOR" ]] && cp $RES_COLOR $CUR_W_COLOR
-	else
-		echof act "Creating canvas: $TOTAL_SIZE"
-		[[ -f "$RES_RESIZE" ]] && convert -size $TOTAL_SIZE 'xc:blue' $CUR_W_RESIZE
-		[[ -f "$RES_DIM" ]] && convert -size $TOTAL_SIZE 'xc:blue' $CUR_W_DIM
-		[[ -f "$RES_BLUR" ]] && convert -size $TOTAL_SIZE 'xc:blue' $CUR_W_BLUR
-		[[ -f "$RES_DIMBLUR" ]] && convert -size $TOTAL_SIZE 'xc:blue' $CUR_W_DIMBLUR
-		[[ -f "$RES_PIXEL" ]] && convert -size $TOTAL_SIZE 'xc:blue' $CUR_W_PIXEL
-		[[ -f "$RES_DIMPIXEL" ]] && convert -size $TOTAL_SIZE 'xc:blue' $CUR_W_DIMPIXEL
-		[[ -f "$RES_COLOR" ]] && convert -size $TOTAL_SIZE 'xc:blue' $CUR_W_COLOR
-
-		echof act "Rendering final wallpaper images..."
-		[[ -f "$CUR_W_RESIZE" ]] && convert $CUR_W_RESIZE $PARAM_RESIZE $CUR_W_RESIZE
-		[[ -f "$CUR_W_DIM" ]] && convert $CUR_W_DIM $PARAM_DIM $CUR_W_DIM
-		[[ -f "$CUR_W_BLUR" ]] && convert $CUR_W_BLUR $PARAM_BLUR $CUR_W_BLUR
-		[[ -f "$CUR_W_DIMBLUR" ]] && convert $CUR_W_DIMBLUR $PARAM_DIMBLUR $CUR_W_DIMBLUR
-		[[ -f "$CUR_W_PIXEL" ]] && convert $CUR_W_PIXEL $PARAM_PIXEL $CUR_W_PIXEL
-		[[ -f "$CUR_W_DIMPIXEL" ]] && convert $CUR_W_DIMPIXEL $PARAM_DIMPIXEL $CUR_W_DIMPIXEL
-		[[ -f "$CUR_W_COLOR" ]] && convert $CUR_W_COLOR $PARAM_COLOR $CUR_W_COLOR
-	fi
+	echof act "Rendering final wallpaper images..."
+	[[ -f "$RES_RESIZE" ]] && cp $RES_RESIZE $CUR_W_RESIZE
+	[[ -f "$RES_DIM" ]] && cp $RES_DIM $CUR_W_DIM
+	[[ -f "$RES_BLUR" ]] && cp $RES_BLUR $CUR_W_BLUR
+	[[ -f "$RES_DIMBLUR" ]] && cp $RES_DIMBLUR $CUR_W_DIMBLUR
+	[[ -f "$RES_PIXEL" ]] && cp $RES_PIXEL $CUR_W_PIXEL
+	[[ -f "$RES_DIMPIXEL" ]] && cp $RES_DIMPIXEL $CUR_W_DIMPIXEL
+	[[ -f "$RES_COLOR" ]] && cp $RES_COLOR $CUR_W_COLOR
 
 	echof act "Rendering final lockscreen images..."
 
@@ -548,52 +485,52 @@ usage() {
 	echo
 	echo "Usage: multilockscreen [-u <PATH>] [-l <EFFECT>] [-w <EFFECT>]"
 	echo
-	echo "  -u --update <PATH>"
-	echo "      Update lock screen image"
+	echo "	-u --update <PATH>"
+	echo "			Update lock screen image"
 	echo
-	echo "  -l --lock <EFFECT>"
-	echo "      Lock screen with cached image"
+	echo "	-l --lock <EFFECT>"
+	echo "			Lock screen with cached image"
 	echo
-	echo "  -w --wall <EFFECT>"
-	echo "      Set wallpaper with cached image"
+	echo "	-w --wall <EFFECT>"
+	echo "			Set wallpaper with cached image"
 	echo
 	echo "Additional arguments:"
 	echo
-	echo "  --display <N>"
-	echo "      Set display to draw loginbox"
+	echo "	--display <N>"
+	echo "			Set display to draw loginbox"
 	echo
-	echo "  --span"
-	echo "      Scale image to span multiple displays"
+	echo "	--span"
+	echo "			Scale image to span multiple displays"
 	echo
-	echo "  --off <N>"
-	echo "      Turn display off after N minutes"
+	echo "	--off <N>"
+	echo "			Turn display off after N minutes"
 	echo
-	echo "  --fx <EFFECT,EFFECT,EFFECT>"
-	echo "      List of effects to generate"
+	echo "	--fx <EFFECT,EFFECT,EFFECT>"
+	echo "			List of effects to generate"
 	echo
-	echo "  --desc <DESCRIPTION>"
-	echo "      Set a description for the new lock screen image"
-	echo "      (Only has an effect in combination with --update)"
+	echo "	--desc <DESCRIPTION>"
+	echo "			Set a description for the new lock screen image"
+	echo "			(Only has an effect in combination with --update)"
 	echo
-	echo "  --show-layout"
-	echo "      Show current keyboard layout"
+	echo "	--show-layout"
+	echo "			Show current keyboard layout"
 	echo
-	echo "  -- <ARGS>"
-	echo "      Pass additional arguments to i3lock"
+	echo "	-- <ARGS>"
+	echo "			Pass additional arguments to i3lock"
 	echo
 	echo "Effects arguments:"
 	echo
-	echo "  --dim <N>"
-	echo "      Dim image N percent (0-100)"
+	echo "	--dim <N>"
+	echo "			Dim image N percent (0-100)"
 	echo
-	echo "  --blur <N>"
-	echo "      Blur image N amount (0.0-1.0)"
+	echo "	--blur <N>"
+	echo "			Blur image N amount (0.0-1.0)"
 	echo
-	echo "  --pixel <N,N>"
-	echo "      Pixelate image with N shrink and N grow (unsupported)"
+	echo "	--pixel <N,N>"
+	echo "			Pixelate image with N shrink and N grow (unsupported)"
 	echo
-	echo "  --color <HEX>"
-	echo "      Solid color background with HEX"
+	echo "	--color <HEX>"
+	echo "			Solid color background with HEX"
 	echo
 	exit 1
 }

--- a/multilockscreen
+++ b/multilockscreen
@@ -95,6 +95,7 @@ lock() {
 	local image="$1"
 
 	i3lock \
+    --no-verify \
 		-i "$image" \
 		-c "$bgcolor" \
 		--screen "$display_on" \
@@ -278,130 +279,37 @@ get_image() {
 
 # scale base image and generate effects
 resize_and_render () {
-
 	local base="$1"
-	local path="$2"
-	local resolution="$3"
+	local resolution="$2"
+
+  local common_image_params=(--cachedir "$CACHE_DIR" --img "$base" --display "$resolution" "0x0")
 
 	# resource paths
-	RES_RESIZE="$path/resize.png"
-	RES_DIM="$path/dim.png"
-	RES_BLUR="$path/blur.png"
-	RES_DIMBLUR="$path/dimblur.png"
-	RES_PIXEL="$path/pixel.png"
-	RES_DIMPIXEL="$path/dimpixel.png"
-	RES_COLOR="$path/color.png"
+  RES_RESIZE="$(getlockimg "${common_image_params[@]}")"
 
-	# resize
-	base_resize "$base" "$RES_RESIZE" "$resolution"
+  # The following variables are intentionally assigned to a (probably)
+  # non-existent file. The rest of this script uses the existence of these files
+  # as a proxy for "is this effect enabled in the fx_list". If an effect is
+  # desired, the corresponding RES_* variable will be assigned to the result
+  # of `getlockimg` in the case-statement below.
+	RES_DIM="$CACHE_DIR/effect-is-disabled.png"
+	RES_BLUR="$CACHE_DIR/effect-is-disabled.png"
+	RES_DIMBLUR="$CACHE_DIR/effect-is-disabled.png"
+	RES_PIXEL="$CACHE_DIR/effect-is-disabled.png"
+	RES_DIMPIXEL="$CACHE_DIR/effect-is-disabled.png"
+	RES_COLOR="$CACHE_DIR/effect-is-disabled.png"
 
 	# effects
 	for effect in "${fx_list[@]}"; do
 		case $effect in
-			dim) fx_dim "$RES_RESIZE" "$RES_DIM";;
-			blur) fx_blur "$RES_RESIZE" "$RES_BLUR" "$resolution";;
-			dimblur) fx_dimblur "$RES_RESIZE" "$RES_DIMBLUR" "$resolution";;
-			pixel) fx_pixel "$RES_RESIZE" "$RES_PIXEL";;
-			dimpixel) fx_dimpixel "$RES_RESIZE" "$RES_DIMPIXEL";;
-			color) fx_color "$RES_COLOR" "$resolution";;
+      dim) RES_DIM="$(getlockimg "${common_image_params[@]}" --effect dim --dim "$dim_level")";;
+      blur) RES_BLUR="$(getlockimg "${common_image_params[@]}" --effect blur --blur "$blur_level")";;
+      dimblur) RES_DIMBLUR="$(getlockimg "${common_image_params[@]}" --effect dimblur --dim "$dim_level" --blur "$blur_level")";;
+      pixel) RES_PIXEL="$(getlockimg "${common_image_params[@]}" --effect pixel --pixel "$pixel_scale")";;
+      dimpixel) RES_DIMPIXEL="$(getlockimg "${common_image_params[@]}" --effect dimpixel --dim "$dim_level" --pixel "$pixel_scale")";;
+      color) RES_COLOR="$(getlockimg "${common_image_params[@]}" --effect color --color "$solid_color")";;
 		esac
 	done
-
-}
-
-# apply resize
-base_resize() {
-
-	local input="$1"
-	local output="$2"
-	local size="$3"
-
-	echof act "Resizing base image..."
-	eval convert "$input" \
-		-resize "$size""^" \
-		-gravity center \
-		-extent "$size" \
-		"$output"
-}
-
-# apply dim
-fx_dim() {
-	local input="$1"
-	local output="$2"
-
-	echof act "Rendering 'dim' effect..."
-	eval convert "$input" \
-		-fill black -colorize "$dim_level"% \
-		"$output"
-}
-
-# apply blur
-fx_blur() {
-	local input="$1"
-	local output="$2"
-	local size="$3"
-
-	echof act "Rendering 'blur' effect..."
-	blur_shrink=$(echo "scale=2; 20 / $blur_level" | bc)
-	blur_sigma=$(echo "scale=2; 0.6 * $blur_level" | bc)
-	eval convert "$input" \
-		-filter Gaussian \
-		-resize "$blur_shrink%" \
-		-define "filter:sigma=$blur_sigma" \
-		-resize "$size^" -gravity center -extent "$size" \
-		"$output"
-}
-
-# apply dimblur
-fx_dimblur() {
-	local input="$1"
-	local output="$2"
-	local size="$3"
-
-	echof act "Rendering 'dimblur' effect..."
-	blur_shrink=$(echo "scale=2; 20 / $blur_level" | bc)
-	blur_sigma=$(echo "scale=2; 0.6 * $blur_level" | bc)
-	eval convert "$input" \
-		-fill black -colorize "$dim_level"% \
-		-filter Gaussian \
-		-resize "$blur_shrink%" \
-		-define "filter:sigma=$blur_sigma" \
-		-resize "$size^" -gravity center -extent "$size" \
-		"$output"
-}
-
-# pixelate
-fx_pixel() {
-	local input="$1"
-	local output="$2"
-
-	echof act "Rendering 'pixel' effect..."
-	IFS=',' read -ra range <<< "$pixel_scale"
-	eval convert "$input" \
-		-scale "${range[0]}"% -scale "${range[1]}"% \
-		"$output"
-}
-
-# apply dimpixel
-fx_dimpixel() {
-	local input="$1"
-	local output="$2"
-
-	echof act "Rendering 'dimpixel' effect..."
-	IFS=',' read -ra range <<< "$pixel_scale"
-	eval convert "$input" \
-		-fill black -colorize "$dim_level"% \
-		-scale "${range[0]}"% -scale "${range[1]}"% \
-		"$output"
-}
-
-# create solid color
-fx_color() {
-	local output="$1"
-	local size="$2"
-
-	echof act "Rendering 'color' effect..."
-	eval convert -size "$size" canvas:\#"$solid_color" "$RES_COLOR"
 }
 
 # create loginbox rectangle, set $RECTANGLE
@@ -505,9 +413,6 @@ update () {
 			positions_desc+=("+$((descrect_x))+$((descrect_y))")
 		fi
 
-		local path="$CACHE_DIR/$id-$device"
-		purge_cache "$path"
-
 		if [ "$span_image" = true ]; then
 			if [ "$id" -gt 1 ]; then
 				continue
@@ -522,9 +427,9 @@ update () {
 		echof info "Resolution: $resolution"
 
 		if [ "$span_image" = true ]; then
-			resize_and_render "$USER_WALL" "$path" "$resolution"
+			resize_and_render "$USER_WALL" "$resolution"
 		else
-			resize_and_render "$USER_WALL" "$path" "$resolution"
+			resize_and_render "$USER_WALL" "$resolution"
 
 			PARAM_RESIZE="$PARAM_RESIZE $RES_RESIZE -geometry $position -composite "
 			PARAM_DIM="$PARAM_DIM $RES_DIM -geometry $position -composite "

--- a/multilockscreen
+++ b/multilockscreen
@@ -381,7 +381,7 @@ update () {
 
 	local compose_params=(--cachedir "$CACHE_DIR" --totalsize "$TOTAL_SIZE")
 	if [ "$span_image" = true ]; then
-		compose_params+=(--img "${IMAGE_PATHS[0]}" --display "$TOTAL_SIZE" "+0+0")
+		compose_params+=(--img "${WALL_LIST[0]}" --display "$TOTAL_SIZE" "+0+0")
 	else
 		compose_params+=(${display_params[@]})
 	fi


### PR DESCRIPTION
@jeffmhubbard First of all, thank you for putting in the work to add multi-screen support.

This PR does a few things:

1. Extract the image generation code into a separate script. This way people can reuse this in the future with, say, plain i3lock or something.
2. Use original file name and target resolution to generate file cache. This way we can change the images and screen configurations without rebuilding the cache every time
3. The main lock script now calls the new script when running with `-u`

As it stands, this change doesn't affect current user experience. I've simply moved the code in `update()` to a new script and added more aggressive caching. This is only a first step. Once this is merged, we can consider deprecating the `-u` step, and have the cache build only the necessary files when user first invokes lock. That way we can get true random image selections (on every lock as opposed to on every update), and we can remove a lot of the cruft with the `fx_list`, too. What do you think?

I do apologize that this PR ended up on the longer side. If you'd like, you can review each commit individually, it might make more sense.